### PR TITLE
Updated insight-scanner to 2.8.7-SNAPSHOT CLM-10576

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -86,8 +86,15 @@
       <dependency>
         <groupId>com.sonatype.nexus</groupId>
         <artifactId>nexus-platform-api</artifactId>
-        <version>3.3.20180828-152410.8e581c6</version>
+        <version>3.3-SNAPSHOT</version>
         <classifier>internal</classifier>
+      </dependency>
+      
+      <!-- bcprov-jdk15on versions before 1.60 have a lot of security vulnerabilities. -->
+      <dependency>
+        <groupId>org.bouncycastle</groupId>
+        <artifactId>bcprov-jdk15on</artifactId>
+        <version>1.60</version>
       </dependency>
 
       <dependency>


### PR DESCRIPTION
Updated the nexus-platform-api dependency to pull in the insight-scanner:2.8.7-SNAPSHOT which has the changes to log a warning when the scanner cannot open an archive.

Warn when the scanner cannot open a file that looks like an archive CLM-10576
https://jenkins.zion.aws.s/job/integrations/job/jenkins/job/sonatype-nexus-platform-plugin-feature/job/CLM-10576_WarnOnBadArchives/lastBuild/