### PR TITLE
NEXUS-17832: Jenkins Plugin unable to determine Nexus version using URL with trailing slash

### DIFF
--- a/src/main/java/org/sonatype/nexus/ci/config/Nxrm3Configuration.groovy
+++ b/src/main/java/org/sonatype/nexus/ci/config/Nxrm3Configuration.groovy
@@ -96,7 +96,8 @@ class Nxrm3Configuration
 
       // check nexus version, warn if < 3.13.0 PRO
       try {
-        def response = new XmlSlurper().parseText(new URL("${nxrmUrl}/service/rest/wonderland/status").text)
+        def statusServiceUrl = "${nxrmUrl}${nxrmUrl.endsWith('/') ? '' : '/'}service/rest/wonderland/status"
+        def response = new XmlSlurper().parseText(new URL(statusServiceUrl).text)
         def edition = response.edition.text()
         def version = response.version.text()
         def (major, minor) = version.tokenize(DOT).take(2).collect { it as int }

--- a/src/test/java/org/sonatype/nexus/ci/config/Nxrm3ConfigurationTest.groovy
+++ b/src/test/java/org/sonatype/nexus/ci/config/Nxrm3ConfigurationTest.groovy
@@ -37,6 +37,9 @@ class Nxrm3ConfigurationTest
   def 'it checks nxrm version'() {
     given:
       URL.metaClass.getText = {
+        if (delegate.path.startsWith('//')) {
+          throw new ConnectException()
+        }
         if (delegate.host.contains('invalid')) {
           return '<?xml version="1.0" encoding="UTF-8" standalone="yes"?><status><edition>PRO</edition><version>3.12' +
               '.0-01</version></status>'
@@ -71,6 +74,7 @@ class Nxrm3ConfigurationTest
           'NXRM PRO 3.12.0-01 found. Some operations require a Nexus Repository Manager Professional server version 3' +
           '.13.0 or newer; use of an incompatible server will result in failed builds.'
       'http://nxrm.valid.com'   | Kind.OK      | ''
+      'http://nxrm.valid.com/'  | Kind.OK      | ''
   }
 
   def 'it tests valid server credentials'() {


### PR DESCRIPTION
Jira: https://issues.sonatype.org/browse/NEXUS-17832
CI: https://jenkins.zion.aws.s/job/integrations/job/jenkins/job/sonatype-nexus-platform-plugin-feature/job/NEXUS-17832_jenkins_determine_version_when_url_trailing_slash/