### PR TITLE
Fix Jenkins Nexus plugin module excludes advance option input CLM-11010

### DIFF
--- a/src/main/java/org/sonatype/nexus/ci/iq/IqPolicyEvaluator.groovy
+++ b/src/main/java/org/sonatype/nexus/ci/iq/IqPolicyEvaluator.groovy
@@ -20,7 +20,7 @@ interface IqPolicyEvaluator
 
   List<ScanPattern> getIqScanPatterns()
 
-  List<ModuleExclude> getModuleExcludes()
+  List<ModuleExclude> getIqModuleExcludes()
 
   Boolean getFailBuildOnNetworkError()
 

--- a/src/main/java/org/sonatype/nexus/ci/iq/IqPolicyEvaluatorBuildStep.groovy
+++ b/src/main/java/org/sonatype/nexus/ci/iq/IqPolicyEvaluatorBuildStep.groovy
@@ -47,7 +47,7 @@ class IqPolicyEvaluatorBuildStep
 
   List<ScanPattern> iqScanPatterns
 
-  List<ModuleExclude> moduleExcludes
+  List<ModuleExclude> iqModuleExcludes
 
   Boolean failBuildOnNetworkError
 
@@ -58,14 +58,14 @@ class IqPolicyEvaluatorBuildStep
   IqPolicyEvaluatorBuildStep(final String iqStage,
                              final IqApplication iqApplication,
                              final List<ScanPattern> iqScanPatterns,
-                             final List<ModuleExclude> moduleExcludes,
+                             final List<ModuleExclude> iqModuleExcludes,
                              final Boolean failBuildOnNetworkError,
                              final String jobCredentialsId)
   {
     this.jobCredentialsId = jobCredentialsId
     this.failBuildOnNetworkError = failBuildOnNetworkError
     this.iqScanPatterns = iqScanPatterns
-    this.moduleExcludes = moduleExcludes
+    this.iqModuleExcludes = iqModuleExcludes
     this.iqStage = iqStage
     this.iqApplication = iqApplication
   }

--- a/src/main/java/org/sonatype/nexus/ci/iq/IqPolicyEvaluatorUtil.groovy
+++ b/src/main/java/org/sonatype/nexus/ci/iq/IqPolicyEvaluatorUtil.groovy
@@ -57,7 +57,7 @@ class IqPolicyEvaluatorUtil
 
       def envVars = run.getEnvironment(listener)
       def expandedScanPatterns = getScanPatterns(iqPolicyEvaluator.iqScanPatterns, envVars)
-      def expandedModuleExcludes = getExpandedModuleExcludes(iqPolicyEvaluator.moduleExcludes, envVars)
+      def expandedModuleExcludes = getExpandedModuleExcludes(iqPolicyEvaluator.iqModuleExcludes, envVars)
 
       def proprietaryConfig = iqClient.getProprietaryConfigForApplicationEvaluation(applicationId)
       def remoteScanner = RemoteScannerFactory.

--- a/src/main/java/org/sonatype/nexus/ci/iq/IqPolicyEvaluatorWorkflowStep.groovy
+++ b/src/main/java/org/sonatype/nexus/ci/iq/IqPolicyEvaluatorWorkflowStep.groovy
@@ -42,7 +42,7 @@ class IqPolicyEvaluatorWorkflowStep
 
   List<ScanPattern> iqScanPatterns
 
-  List<ModuleExclude> moduleExcludes
+  List<ModuleExclude> iqModuleExcludes
 
   Boolean failBuildOnNetworkError
 
@@ -54,8 +54,8 @@ class IqPolicyEvaluatorWorkflowStep
   }
 
   @DataBoundSetter
-  public void setModuleExcludes(final List<ModuleExclude> moduleExcludes) {
-    this.moduleExcludes = moduleExcludes
+  public void setIqModuleExcludes(final List<ModuleExclude> iqModuleExcludes) {
+    this.iqModuleExcludes = iqModuleExcludes
   }
 
   @DataBoundSetter


### PR DESCRIPTION
The problem was the Jenkins "Invoke Nexus Policy Evaluation" advanced option "Module excludes" does not save the inputted value.

<img width="924" alt="screen shot 2018-10-17 at 2 56 59 pm" src="https://user-images.githubusercontent.com/4838322/47110200-2c5dd980-d21e-11e8-932b-f494e8a108cf.png">

The solution was to use the wrapping list `f.repeatable(field: 'iqModuleExcludes', minimum: '0')` instead of the textbox `moduleExclude` in the `config.groovy`.

https://jenkins.zion.aws.s/job/integrations/job/jenkins/job/sonatype-nexus-platform-plugin-feature/job/CLM-11010-Module-excludes-not-persist/

https://issues.sonatype.org/browse/CLM-11010