### PR TITLE
Expand environment variables for application IDs CLM-11138

### DIFF
--- a/src/main/java/org/sonatype/nexus/ci/iq/IqPolicyEvaluatorUtil.groovy
+++ b/src/main/java/org/sonatype/nexus/ci/iq/IqPolicyEvaluatorUtil.groovy
@@ -40,7 +40,8 @@ class IqPolicyEvaluatorUtil
                                                     final TaskListener listener)
   {
     try {
-      String applicationId = iqPolicyEvaluator.getIqApplication()?.applicationId
+      EnvVars envVars = run.getEnvironment(listener)
+      String applicationId = envVars.expand(iqPolicyEvaluator.getIqApplication()?.applicationId)
 
       checkArgument(iqPolicyEvaluator.iqStage && applicationId, 'Arguments iqApplication and iqStage are mandatory')
 
@@ -55,7 +56,6 @@ class IqPolicyEvaluatorUtil
       def verified = iqClient.verifyOrCreateApplication(applicationId)
       checkArgument(verified, 'The application ID ' + applicationId + ' is invalid.')
 
-      def envVars = run.getEnvironment(listener)
       def expandedScanPatterns = getScanPatterns(iqPolicyEvaluator.iqScanPatterns, envVars)
       def expandedModuleExcludes = getExpandedModuleExcludes(iqPolicyEvaluator.iqModuleExcludes, envVars)
 


### PR DESCRIPTION
Expands environment variables for application IDs. Previously, application IDs that were manually entered rather than selected in the dropdown would not be subject to environment variable expansion, producing unexpected results and invalid application IDs. Also adds additional integration tests (as opposed to unit tests) to verify the expansion behavior in the context of how Jenkins handles the variable expansion, as opposed to just mocking the relevant parts of the code.

https://issues.sonatype.org/browse/CLM-11138
https://jenkins.zion.aws.s/job/integrations/job/jenkins/job/sonatype-nexus-platform-plugin-feature/job/CLM-11138_EnvironmentVariableExpansion/