### PR TITLE
Nexus-18262: use api for version test including tests

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -86,7 +86,7 @@
       <dependency>
         <groupId>com.sonatype.nexus</groupId>
         <artifactId>nexus-platform-api</artifactId>
-        <version>3.4-SNAPSHOT</version>
+        <version>3.4.20181205-180005.1567c7b</version>
         <classifier>internal</classifier>
       </dependency>
       

--- a/pom.xml
+++ b/pom.xml
@@ -86,7 +86,7 @@
       <dependency>
         <groupId>com.sonatype.nexus</groupId>
         <artifactId>nexus-platform-api</artifactId>
-        <version>3.4.20181203-154456.a0c3711</version>
+        <version>3.4-SNAPSHOT</version>
         <classifier>internal</classifier>
       </dependency>
       

--- a/pom.xml
+++ b/pom.xml
@@ -86,7 +86,7 @@
       <dependency>
         <groupId>com.sonatype.nexus</groupId>
         <artifactId>nexus-platform-api</artifactId>
-        <version>3.3.20181025-095610.1ce86ad</version>
+        <version>3.4-SNAPSHOT</version>
         <classifier>internal</classifier>
       </dependency>
       

--- a/pom.xml
+++ b/pom.xml
@@ -86,7 +86,7 @@
       <dependency>
         <groupId>com.sonatype.nexus</groupId>
         <artifactId>nexus-platform-api</artifactId>
-        <version>3.4-SNAPSHOT</version>
+        <version>3.4.20181203-154456.a0c3711</version>
         <classifier>internal</classifier>
       </dependency>
       

--- a/src/main/java/org/sonatype/nexus/ci/config/Nxrm3Configuration.groovy
+++ b/src/main/java/org/sonatype/nexus/ci/config/Nxrm3Configuration.groovy
@@ -98,7 +98,8 @@ class Nxrm3Configuration
       }
 
       if (badVersionMsg) {
-        warning("${LINE_SEPARATOR}${LINE_SEPARATOR} ${badVersionMsg} ${INVALID_VERSION_WARNING}")
+        warning("Nexus Repository Manager 3.x connection succeeded " +
+                "${LINE_SEPARATOR}${LINE_SEPARATOR} ${badVersionMsg} ${INVALID_VERSION_WARNING}")
       }
       else {
         try {

--- a/src/main/java/org/sonatype/nexus/ci/config/Nxrm3Configuration.groovy
+++ b/src/main/java/org/sonatype/nexus/ci/config/Nxrm3Configuration.groovy
@@ -83,7 +83,7 @@ class Nxrm3Configuration
       def badVersionMsg = ''
 
       try {
-        // check nexus version, warn if < 3.13.0 PRO
+        // check nexus version and warn if < 3.13.0 PRO
         def client = nexus3Client(serverUrl, credentialsId)
         def sv = client.getVersion()
         def (major, minor) = sv.version.tokenize(DOT).take(2).collect { it as int }

--- a/src/main/java/org/sonatype/nexus/ci/config/Nxrm3Configuration.groovy
+++ b/src/main/java/org/sonatype/nexus/ci/config/Nxrm3Configuration.groovy
@@ -102,13 +102,13 @@ class Nxrm3Configuration
       }
 
       if (badVersionMsg) {
-        warning(CONNECTION_SUCCEEDED +
-                "${LINE_SEPARATOR}${LINE_SEPARATOR} ${badVersionMsg} ${INVALID_VERSION_WARNING}")
+        warning("${CONNECTION_SUCCEEDED} ${LINE_SEPARATOR}${LINE_SEPARATOR} ${badVersionMsg} " +
+            "${INVALID_VERSION_WARNING}")
       }
       else {
         try {
           repositories = getApplicableRepositories(serverUrl, credentialsId, 'maven2')
-          ok(CONNECTION_SUCCEEDED + " (${repositories.size()} hosted maven2 repositories)")
+          ok("${CONNECTION_SUCCEEDED} (${repositories.size()} hosted maven2 repositories)")
         }
         catch (RepositoryManagerException e) {
           return error(e, CONNECTION_FAILED)

--- a/src/main/java/org/sonatype/nexus/ci/config/Nxrm3Configuration.groovy
+++ b/src/main/java/org/sonatype/nexus/ci/config/Nxrm3Configuration.groovy
@@ -91,7 +91,6 @@ class Nxrm3Configuration
         if (!sv.edition.equalsIgnoreCase('pro') || major < MAJOR_VERSION_REQ || minor < MINOR_VERSION_REQ) {
           badVersionMsg = "NXRM ${sv.edition} ${sv.version} found."
         }
-
       }
       catch (Exception e) {
         log.log(WARNING, "Unsuccessful request to ${serverUrl} for version information for compatibility check", e)

--- a/src/main/java/org/sonatype/nexus/ci/config/Nxrm3Configuration.groovy
+++ b/src/main/java/org/sonatype/nexus/ci/config/Nxrm3Configuration.groovy
@@ -43,7 +43,7 @@ class Nxrm3Configuration
   private static final String DOT = '.'
 
   private static final String INVALID_VERSION_WARNING = "Some operations require Nexus Repository Manager " +
-      "Professional server version ${[MAJOR_VERSION_REQ, MINOR_VERSION_REQ, PATCH_VERSION_REQ].join(DOT)} or " +
+      "Professional server version ${MAJOR_VERSION_REQ}.${MINOR_VERSION_REQ}.${PATCH_VERSION_REQ} or " +
       "newer; use of an incompatible server could result in failed builds."
 
   @SuppressWarnings('ParameterCount')

--- a/src/main/java/org/sonatype/nexus/ci/config/Nxrm3Configuration.groovy
+++ b/src/main/java/org/sonatype/nexus/ci/config/Nxrm3Configuration.groovy
@@ -87,7 +87,7 @@ class Nxrm3Configuration
       def badVersionMsg = ''
 
       try {
-        // check nexus version, warn if < 3.13.0 PRO
+        // check nexus version and warn if < 3.13.0 PRO
         def client = nexus3Client(serverUrl, credentialsId)
         def sv = client.getVersion()
         def (major, minor) = sv.version.tokenize(DOT).take(2).collect { it as int }

--- a/src/main/java/org/sonatype/nexus/ci/config/Nxrm3Configuration.groovy
+++ b/src/main/java/org/sonatype/nexus/ci/config/Nxrm3Configuration.groovy
@@ -83,7 +83,7 @@ class Nxrm3Configuration
       def badVersionMsg = ''
 
       try {
-        // check nexus version and warn if < 3.13.0 PRO
+        // check nexus version, warn if < 3.13.0 PRO
         def client = nexus3Client(serverUrl, credentialsId)
         def sv = client.getVersion()
         def (major, minor) = sv.version.tokenize(DOT).take(2).collect { it as int }

--- a/src/main/java/org/sonatype/nexus/ci/config/Nxrm3Configuration.groovy
+++ b/src/main/java/org/sonatype/nexus/ci/config/Nxrm3Configuration.groovy
@@ -89,12 +89,12 @@ class Nxrm3Configuration
        * also if anonymous access is disabled the endpoint will show 0 repositories without credentials which is
        * potentially confusing
        */
-      try {
-        repositories = getApplicableRepositories(serverUrl, credentialsId, 'maven2')
-      }
-      catch (RepositoryManagerException e) {
-        return error(e, 'Nexus Repository Manager 3.x connection failed')
-      }
+//      try {
+//        repositories = getApplicableRepositories(serverUrl, credentialsId, 'maven2')
+//      }
+//      catch (RepositoryManagerException e) {
+//        return error(e, 'Nexus Repository Manager 3.x connection failed')
+//      }
 
       try {
         // check nexus version, warn if < 3.13.0 PRO
@@ -105,19 +105,28 @@ class Nxrm3Configuration
         if (!sv.edition.equalsIgnoreCase('pro') || major < MAJOR_VERSION_REQ || minor < MINOR_VERSION_REQ) {
           badVersionMsg = "NXRM ${sv.edition} ${sv.version} found."
         }
+
       }
       catch (Exception e) {
         log.log(WARNING, "Unsuccessful request to ${serverUrl} for version information for compatibility check", e)
-        badVersionMsg = 'Unable to determine Nexus Repository Manager version.'
+//        badVersionMsg = 'Unable to determine Nexus Repository Manager version.'
+        return error(e, 'Nexus Repository Manager 3.x connection failed')
       }
 
       if (badVersionMsg) {
         warning(
-            "Nexus Repository Manager 3.x connection succeeded (${repositories.size()} hosted maven2 repositories)" +
+//            "Nexus Repository Manager 3.x connection succeeded (${repositories.size()} hosted maven2 repositories)" +
                 "${LINE_SEPARATOR}${LINE_SEPARATOR} ${badVersionMsg} ${INVALID_VERSION_WARNING}")
       }
       else {
-        ok("Nexus Repository Manager 3.x connection succeeded (${repositories.size()} hosted maven2 repositories)")
+        try {
+          repositories = getApplicableRepositories(serverUrl, credentialsId, 'maven2')
+          ok("Nexus Repository Manager 3.x connection succeeded (${repositories.size()} hosted maven2 repositories)")
+        }
+        catch (RepositoryManagerException e) {
+          return error(e, 'Nexus Repository Manager 3.x connection failed')
+        }
+
       }
     }
   }

--- a/src/main/java/org/sonatype/nexus/ci/config/Nxrm3Configuration.groovy
+++ b/src/main/java/org/sonatype/nexus/ci/config/Nxrm3Configuration.groovy
@@ -46,6 +46,10 @@ class Nxrm3Configuration
       "Professional server version ${MAJOR_VERSION_REQ}.${MINOR_VERSION_REQ}.${PATCH_VERSION_REQ} or " +
       "newer; use of an incompatible server could result in failed builds."
 
+  private static final String CONNECTION_SUCCEEDED = 'Nexus Repository Manager 3.x connection succeeded'
+
+  private static final String CONNECTION_FAILED = 'Nexus Repository Manager 3.x connection failed'
+
   @SuppressWarnings('ParameterCount')
   @DataBoundConstructor
   Nxrm3Configuration(final String id,
@@ -92,22 +96,22 @@ class Nxrm3Configuration
           badVersionMsg = "NXRM ${sv.edition} ${sv.version} found."
         }
       }
-      catch (Exception e) {
+      catch (RepositoryManagerException e) {
         log.log(WARNING, "Unsuccessful request to ${serverUrl} for version information for compatibility check", e)
-        return error(e, 'Nexus Repository Manager 3.x connection failed')
+        return error(e, CONNECTION_FAILED)
       }
 
       if (badVersionMsg) {
-        warning("Nexus Repository Manager 3.x connection succeeded " +
+        warning(CONNECTION_SUCCEEDED +
                 "${LINE_SEPARATOR}${LINE_SEPARATOR} ${badVersionMsg} ${INVALID_VERSION_WARNING}")
       }
       else {
         try {
           repositories = getApplicableRepositories(serverUrl, credentialsId, 'maven2')
-          ok("Nexus Repository Manager 3.x connection succeeded (${repositories.size()} hosted maven2 repositories)")
+          ok(CONNECTION_SUCCEEDED + " (${repositories.size()} hosted maven2 repositories)")
         }
         catch (RepositoryManagerException e) {
-          return error(e, 'Nexus Repository Manager 3.x connection failed')
+          return error(e, CONNECTION_FAILED)
         }
       }
     }

--- a/src/main/java/org/sonatype/nexus/ci/config/Nxrm3Configuration.groovy
+++ b/src/main/java/org/sonatype/nexus/ci/config/Nxrm3Configuration.groovy
@@ -82,20 +82,6 @@ class Nxrm3Configuration
       def repositories
       def badVersionMsg = ''
 
-      /*
-       * note: consider removing this and only verifying version as the v1 endpoints aren't available pre 3.13 which
-       * would result in a connection failure even tho upload will work with 3.9+
-       *
-       * also if anonymous access is disabled the endpoint will show 0 repositories without credentials which is
-       * potentially confusing
-       */
-//      try {
-//        repositories = getApplicableRepositories(serverUrl, credentialsId, 'maven2')
-//      }
-//      catch (RepositoryManagerException e) {
-//        return error(e, 'Nexus Repository Manager 3.x connection failed')
-//      }
-
       try {
         // check nexus version, warn if < 3.13.0 PRO
         def client = nexus3Client(serverUrl, credentialsId)
@@ -109,14 +95,11 @@ class Nxrm3Configuration
       }
       catch (Exception e) {
         log.log(WARNING, "Unsuccessful request to ${serverUrl} for version information for compatibility check", e)
-//        badVersionMsg = 'Unable to determine Nexus Repository Manager version.'
         return error(e, 'Nexus Repository Manager 3.x connection failed')
       }
 
       if (badVersionMsg) {
-        warning(
-//            "Nexus Repository Manager 3.x connection succeeded (${repositories.size()} hosted maven2 repositories)" +
-                "${LINE_SEPARATOR}${LINE_SEPARATOR} ${badVersionMsg} ${INVALID_VERSION_WARNING}")
+        warning("${LINE_SEPARATOR}${LINE_SEPARATOR} ${badVersionMsg} ${INVALID_VERSION_WARNING}")
       }
       else {
         try {

--- a/src/main/java/org/sonatype/nexus/ci/config/Nxrm3Configuration.groovy
+++ b/src/main/java/org/sonatype/nexus/ci/config/Nxrm3Configuration.groovy
@@ -12,8 +12,6 @@
  */
 package org.sonatype.nexus.ci.config
 
-import java.util.logging.Level
-
 import com.sonatype.nexus.api.exception.RepositoryManagerException
 
 import groovy.util.logging.Log
@@ -22,13 +20,15 @@ import hudson.util.FormValidation
 import org.kohsuke.stapler.DataBoundConstructor
 import org.kohsuke.stapler.QueryParameter
 
-import static hudson.util.FormValidation.Kind.OK
 import static hudson.util.FormValidation.error
 import static hudson.util.FormValidation.ok
 import static hudson.util.FormValidation.warning
+import static java.util.logging.Level.WARNING
+import static org.apache.commons.lang.SystemUtils.LINE_SEPARATOR
 import static org.sonatype.nexus.ci.config.NxrmConfiguration.NxrmDescriptor
 import static org.sonatype.nexus.ci.config.NxrmVersion.NEXUS_3
 import static org.sonatype.nexus.ci.util.Nxrm3Util.getApplicableRepositories
+import static org.sonatype.nexus.ci.util.RepositoryManagerClientUtil.nexus3Client
 
 @Log
 class Nxrm3Configuration
@@ -41,6 +41,10 @@ class Nxrm3Configuration
   private static final int PATCH_VERSION_REQ = 0
 
   private static final String DOT = '.'
+
+  private static final String INVALID_VERSION_WARNING = "Some operations require Nexus Repository Manager " +
+      "Professional server version ${[MAJOR_VERSION_REQ, MINOR_VERSION_REQ, PATCH_VERSION_REQ].join(DOT)} or " +
+      "newer; use of an incompatible server could result in failed builds."
 
   @SuppressWarnings('ParameterCount')
   @DataBoundConstructor
@@ -75,49 +79,46 @@ class Nxrm3Configuration
     FormValidation doVerifyCredentials(@QueryParameter String serverUrl, @QueryParameter String credentialsId)
         throws IOException
     {
+      def repositories
+      def badVersionMsg = ''
+
+      /*
+       * note: consider removing this and only verifying version as the v1 endpoints aren't available pre 3.13 which
+       * would result in a connection failure even tho upload will work with 3.9+
+       *
+       * also if anonymous access is disabled the endpoint will show 0 repositories without credentials which is
+       * potentially confusing
+       */
       try {
-        def repositories = getApplicableRepositories(serverUrl, credentialsId, 'maven2')
-        ok("Nexus Repository Manager 3.x connection succeeded (${repositories.size()} hosted maven2 repositories)")
+        repositories = getApplicableRepositories(serverUrl, credentialsId, 'maven2')
       }
       catch (RepositoryManagerException e) {
-        error(e, 'Nexus Repository Manager 3.x connection failed')
-      }
-    }
-
-    @SuppressWarnings('CatchException')
-    @Override
-    FormValidation doCheckServerUrl(@QueryParameter String value) {
-      def nxrmUrl = value
-      def validation = super.doCheckServerUrl(value)
-
-      if (validation.kind != OK) {
-        return validation
+        return error(e, 'Nexus Repository Manager 3.x connection failed')
       }
 
-      // check nexus version, warn if < 3.13.0 PRO
       try {
-        def statusServiceUrl = "${nxrmUrl}${nxrmUrl.endsWith('/') ? '' : '/'}service/rest/wonderland/status"
-        def response = new XmlSlurper().parseText(new URL(statusServiceUrl).text)
-        def edition = response.edition.text()
-        def version = response.version.text()
-        def (major, minor) = version.tokenize(DOT).take(2).collect { it as int }
+        // check nexus version, warn if < 3.13.0 PRO
+        def client = nexus3Client(serverUrl, credentialsId)
+        def sv = client.getVersion()
+        def (major, minor) = sv.version.tokenize(DOT).take(2).collect { it as int }
 
-        if (!edition.equalsIgnoreCase('pro') || major < MAJOR_VERSION_REQ || minor < MINOR_VERSION_REQ) {
-          return warning(
-              "NXRM ${edition} ${version} found. Some operations require a Nexus Repository Manager Professional " +
-                  "server version ${[MAJOR_VERSION_REQ, MINOR_VERSION_REQ, PATCH_VERSION_REQ].join(DOT)} or newer; " +
-                  "use of an incompatible server will result in failed builds.")
+        if (!sv.edition.equalsIgnoreCase('pro') || major < MAJOR_VERSION_REQ || minor < MINOR_VERSION_REQ) {
+          badVersionMsg = "NXRM ${sv.edition} ${sv.version} found."
         }
       }
       catch (Exception e) {
-        log.log(Level.WARNING, "Unsuccessful request to ${nxrmUrl} for version information for compatibility check", e)
-
-        return warning(
-            'Unable to determine Nexus Repository Manager version. Certain operations may not be compatible with your' +
-                ' server which could result in failed builds.')
+        log.log(WARNING, "Unsuccessful request to ${serverUrl} for version information for compatibility check", e)
+        badVersionMsg = 'Unable to determine Nexus Repository Manager version.'
       }
 
-      ok()
+      if (badVersionMsg) {
+        warning(
+            "Nexus Repository Manager 3.x connection succeeded (${repositories.size()} hosted maven2 repositories)" +
+                "${LINE_SEPARATOR}${LINE_SEPARATOR} ${badVersionMsg} ${INVALID_VERSION_WARNING}")
+      }
+      else {
+        ok("Nexus Repository Manager 3.x connection succeeded (${repositories.size()} hosted maven2 repositories)")
+      }
     }
   }
 }

--- a/src/main/java/org/sonatype/nexus/ci/config/Nxrm3Configuration.groovy
+++ b/src/main/java/org/sonatype/nexus/ci/config/Nxrm3Configuration.groovy
@@ -108,7 +108,6 @@ class Nxrm3Configuration
         catch (RepositoryManagerException e) {
           return error(e, 'Nexus Repository Manager 3.x connection failed')
         }
-
       }
     }
   }

--- a/src/main/java/org/sonatype/nexus/ci/util/RepositoryManagerClientUtil.groovy
+++ b/src/main/java/org/sonatype/nexus/ci/util/RepositoryManagerClientUtil.groovy
@@ -23,7 +23,6 @@ import com.sonatype.nexus.api.repository.v3.RepositoryManagerV3Client
 import com.sonatype.nexus.api.repository.v3.RepositoryManagerV3ClientBuilder
 
 import org.sonatype.nexus.ci.config.Nxrm3Configuration
-import org.sonatype.nexus.ci.config.NxrmVersion
 
 import com.cloudbees.plugins.credentials.CredentialsMatchers
 import com.cloudbees.plugins.credentials.CredentialsProvider

--- a/src/test/java/org/sonatype/nexus/ci/config/Nxrm3ConfigurationTest.groovy
+++ b/src/test/java/org/sonatype/nexus/ci/config/Nxrm3ConfigurationTest.groovy
@@ -35,27 +35,10 @@ class Nxrm3ConfigurationTest
   }
 
   def 'it checks nxrm version'() {
-    given:
-      URL.metaClass.getText = {
-        if (delegate.path.startsWith('//')) {
-          throw new ConnectException()
-        }
-        if (delegate.host.contains('invalid')) {
-          return '<?xml version="1.0" encoding="UTF-8" standalone="yes"?><status><edition>PRO</edition><version>3.12' +
-              '.0-01</version></status>'
-        }
-        else if (delegate.host.contains('valid')) {
-          return '<?xml version="1.0" encoding="UTF-8" standalone="yes"?><status><edition>PRO</edition><version>3.13' +
-              '.0-01</version></status>'
-        }
-        else {
-          throw new ConnectException()
-        }
-      }
-
     when:
-      "checking $url for nxrm version"
-      def validation = descriptor.doCheckServerUrl(url)
+      "checking $serverUrl for nxrm version"
+      client.getVersion() >> new com.sonatype.nexus.api.repository.v3.NxrmVersion(version, edition)
+      def validation = descriptor.doVerifyCredentials(serverUrl, credentialsId)
 
     then:
       "it returns $kind with message $message"
@@ -66,20 +49,17 @@ class Nxrm3ConfigurationTest
       GroovySystem.metaClassRegistry.setMetaClass(URL, null)
 
     where:
-      url                       | kind         | message
-      'http://foo.com'          | Kind.WARNING |
-          'Unable to determine Nexus Repository Manager version. Certain operations may not be compatible with your ' +
-          'server which could result in failed builds.'
-      'http://nxrm.invalid.com' | Kind.WARNING |
-          'NXRM PRO 3.12.0-01 found. Some operations require a Nexus Repository Manager Professional server version 3' +
-          '.13.0 or newer; use of an incompatible server will result in failed builds.'
-      'http://nxrm.valid.com'   | Kind.OK      | ''
-      'http://nxrm.valid.com/'  | Kind.OK      | ''
+      kind         | serverUrl                 | credentialsId   | version | edition | message
+      Kind.WARNING | 'http://foo.com'          | 'credentialsId' | '3.13.0'| 'PRO'   | 'Unable to determine Nexus Repository Manager version.'
+      Kind.WARNING | 'http://nxrm.invalid.com' | 'credentialsId' | '3.12.1'| 'PRO'   | 'Unable to determine Nexus Repository Manager version.'
+      Kind.OK      | 'http://nxrm.valid.com'   | 'credentialsId' | '3.13.0'| 'OSS'   | 'NXRM OSS 3.13.0 found. Some operations require a Nexus Repository Manager Professional server version 3.13.0 or newer; use of an incompatible server will result in failed builds. '
+      Kind.OK      | 'http://nxrm.valid.com/'  | 'credentialsId' | '3.13.0'| 'PRO'   | 'Nexus Repository Manager 3.x connection succeeded (0 hosted maven2 repositories'
   }
 
   def 'it tests valid server credentials'() {
     when:
       client.getRepositories() >> repositories
+      client.getVersion() >> new com.sonatype.nexus.api.repository.v3.NxrmVersion("3.13.0", "PRO")
 
     and:
       FormValidation validation = descriptor.doVerifyCredentials(serverUrl, credentialsId)

--- a/src/test/java/org/sonatype/nexus/ci/config/Nxrm3ConfigurationTest.groovy
+++ b/src/test/java/org/sonatype/nexus/ci/config/Nxrm3ConfigurationTest.groovy
@@ -93,7 +93,7 @@ class Nxrm3ConfigurationTest
   def 'it tests valid server credentials'() {
     when:
       client.getRepositories() >> repositories
-      client.getVersion() >> new com.sonatype.nexus.api.repository.v3.NxrmVersion("3.13.0", "PRO")
+      client.getVersion() >> new com.sonatype.nexus.api.repository.v3.NxrmVersion(version, edition)
 
     and:
       FormValidation validation = descriptor.doVerifyCredentials(serverUrl, credentialsId)
@@ -103,6 +103,8 @@ class Nxrm3ConfigurationTest
       validation.message == "Nexus Repository Manager 3.x connection succeeded (2 hosted maven2 repositories)"
 
     where:
+      version << ['3.13.0']
+      edition << ['PRO']
       serverUrl << ['serverUrl']
       credentialsId << ['credentialsId']
       repositories << [
@@ -137,7 +139,7 @@ class Nxrm3ConfigurationTest
 
   def 'it tests invalid server credentials'() {
     when:
-      client.getRepositories() >> { throw new RepositoryManagerException("something went wrong") }
+      client.getVersion() >> { throw new RepositoryManagerException("something went wrong") }
 
     and:
       FormValidation validation = descriptor.doVerifyCredentials(serverUrl, credentialsId)
@@ -154,15 +156,20 @@ class Nxrm3ConfigurationTest
   def 'defaults to anonymous access with no credentials'() {
     when:
       GroovySpy(Nxrm3Util.class, global: true)
+      client.getVersion() >> new com.sonatype.nexus.api.repository.v3.NxrmVersion(version, edition)
       client.getRepositories() >> []
+
     and:
-      client.getVersion() >> new com.sonatype.nexus.api.repository.v3.NxrmVersion("3.13.0", "PRO")
-      descriptor.doVerifyCredentials(serverUrl, credentialsId)
+      FormValidation validation =descriptor.doVerifyCredentials(serverUrl, credentialsId)
 
     then:
       1 * Nxrm3Util.getApplicableRepositories(serverUrl, null, 'maven2')
+      validation.kind == Kind.OK
+      validation.message == "Nexus Repository Manager 3.x connection succeeded (0 hosted maven2 repositories)"
 
     where:
+      version << ['3.13.0']
+      edition << ['PRO']
       serverUrl << ['serverUrl']
       credentialsId << [null]
   }

--- a/src/test/java/org/sonatype/nexus/ci/config/Nxrm3ConfigurationTest.groovy
+++ b/src/test/java/org/sonatype/nexus/ci/config/Nxrm3ConfigurationTest.groovy
@@ -71,7 +71,7 @@ class Nxrm3ConfigurationTest
           ]
   }
 
-  def 'it checks nxrm version for invalid urls'() {
+  def 'attempts to check nxrm version when using invalid urls'() {
     when:
       "checking $serverUrl for nxrm version"
       client.getVersion() >> { throw new RepositoryManagerException("something went wrong") }
@@ -156,6 +156,7 @@ class Nxrm3ConfigurationTest
       GroovySpy(Nxrm3Util.class, global: true)
       client.getRepositories() >> []
     and:
+      client.getVersion() >> new com.sonatype.nexus.api.repository.v3.NxrmVersion("3.13.0", "PRO")
       descriptor.doVerifyCredentials(serverUrl, credentialsId)
 
     then:

--- a/src/test/java/org/sonatype/nexus/ci/config/Nxrm3ConfigurationTest.groovy
+++ b/src/test/java/org/sonatype/nexus/ci/config/Nxrm3ConfigurationTest.groovy
@@ -21,7 +21,6 @@ import org.sonatype.nexus.ci.config.NxrmConfiguration.NxrmDescriptor
 import org.sonatype.nexus.ci.util.Nxrm3Util
 import org.sonatype.nexus.ci.util.RepositoryManagerClientUtil
 
-
 import hudson.util.FormValidation
 import hudson.util.FormValidation.Kind
 

--- a/src/test/java/org/sonatype/nexus/ci/config/Nxrm3ConfigurationTest.groovy
+++ b/src/test/java/org/sonatype/nexus/ci/config/Nxrm3ConfigurationTest.groovy
@@ -13,12 +13,14 @@
 package org.sonatype.nexus.ci.config
 
 import com.sonatype.nexus.api.exception.RepositoryManagerException
+import com.sonatype.nexus.api.repository.v3.NxrmVersion
 import com.sonatype.nexus.api.repository.v3.RepositoryManagerV3Client
 
 import org.sonatype.nexus.ci.config.Nxrm3Configuration.DescriptorImpl
 import org.sonatype.nexus.ci.config.NxrmConfiguration.NxrmDescriptor
 import org.sonatype.nexus.ci.util.Nxrm3Util
 import org.sonatype.nexus.ci.util.RepositoryManagerClientUtil
+
 
 import hudson.util.FormValidation
 import hudson.util.FormValidation.Kind
@@ -37,7 +39,7 @@ class Nxrm3ConfigurationTest
   def 'it checks nxrm version'() {
     when:
       "checking $serverUrl for nxrm version"
-      client.getVersion() >> new com.sonatype.nexus.api.repository.v3.NxrmVersion(version, edition)
+      client.getVersion() >> new NxrmVersion(version, edition)
       client.getRepositories() >> repositories
       def validation = descriptor.doVerifyCredentials(serverUrl, credentialsId)
 
@@ -93,7 +95,7 @@ class Nxrm3ConfigurationTest
   def 'it tests valid server credentials'() {
     when:
       client.getRepositories() >> repositories
-      client.getVersion() >> new com.sonatype.nexus.api.repository.v3.NxrmVersion(version, edition)
+      client.getVersion() >> new NxrmVersion(version, edition)
 
     and:
       FormValidation validation = descriptor.doVerifyCredentials(serverUrl, credentialsId)
@@ -156,11 +158,11 @@ class Nxrm3ConfigurationTest
   def 'defaults to anonymous access with no credentials'() {
     when:
       GroovySpy(Nxrm3Util.class, global: true)
-      client.getVersion() >> new com.sonatype.nexus.api.repository.v3.NxrmVersion(version, edition)
+      client.getVersion() >> new NxrmVersion(version, edition)
       client.getRepositories() >> []
 
     and:
-      FormValidation validation =descriptor.doVerifyCredentials(serverUrl, credentialsId)
+      FormValidation validation = descriptor.doVerifyCredentials(serverUrl, null)
 
     then:
       1 * Nxrm3Util.getApplicableRepositories(serverUrl, null, 'maven2')
@@ -171,7 +173,6 @@ class Nxrm3ConfigurationTest
       version << ['3.13.0']
       edition << ['PRO']
       serverUrl << ['serverUrl']
-      credentialsId << [null]
   }
 
   @Override


### PR DESCRIPTION
Branch has been reviewed and approved via PR in the upstream: 
https://github.com/jenkinsci/nexus-platform-plugin/pull/60.
(NOTE: The original PR was incorrectly created against the upstream repo.)

Since the above was approved the only additional commits were:
https://github.com/sonatype/jenkins-nexus-platform-plugin/pull/41/commits/42acaccdc240ca8a6394db83ee074c99142f05c4
and 
https://github.com/sonatype/jenkins-nexus-platform-plugin/pull/41/commits/2895f7a7e030e33f3203616e48c16a0d2ab7f1c3

JIRA: https://issues.sonatype.org/browse/NEXUS-18262
CI: https://jenkins.zion.aws.s/job/integrations/job/jenkins/job/sonatype-nexus-platform-plugin-feature/job/NEXUS-18262_use_api_for_version_test_including_tests/