### PR TITLE
INT-2451 Test to try to cover JEP-200 issues

### DIFF
--- a/src/main/resources/META-INF/hudson.remoting.ClassFilter
+++ b/src/main/resources/META-INF/hudson.remoting.ClassFilter
@@ -12,3 +12,7 @@ com.sonatype.nexus.api.iq.PolicyFact
 com.sonatype.nexus.api.iq.ComponentFact
 com.sonatype.nexus.api.iq.ConstraintFact
 com.sonatype.nexus.api.iq.ConditionFact
+com.sonatype.nexus.api.iq.ComponentIdentifier
+com.sonatype.nexus.api.iq.ComponentDisplayName
+com.sonatype.nexus.api.iq.ComponentDisplayNamePart
+com.sonatype.nexus.api.iq.Action

--- a/src/test/java/org/sonatype/nexus/ci/config/ComToOrgMigratorIntegrationTest.groovy
+++ b/src/test/java/org/sonatype/nexus/ci/config/ComToOrgMigratorIntegrationTest.groovy
@@ -18,6 +18,7 @@ import com.sonatype.nexus.api.iq.internal.InternalIqClient
 import com.sonatype.nexus.api.iq.internal.InternalIqClientBuilder
 import com.sonatype.nexus.api.iq.scan.ScanResult
 
+import org.sonatype.nexus.ci.iq.ClassFilterLoggingTestTrait
 import org.sonatype.nexus.ci.iq.IqPolicyEvaluatorBuildStep
 import org.sonatype.nexus.ci.nxrm.ComponentUploader
 import org.sonatype.nexus.ci.nxrm.ComponentUploaderFactory
@@ -33,6 +34,7 @@ import spock.lang.Specification
 
 class ComToOrgMigratorIntegrationTest
     extends Specification
+    implements ClassFilterLoggingTestTrait
 {
   @Rule
   public JenkinsRule jenkins = new JenkinsRule().withExistingHome(new File(

--- a/src/test/java/org/sonatype/nexus/ci/iq/ClassFilterLoggingTestTrait.groovy
+++ b/src/test/java/org/sonatype/nexus/ci/iq/ClassFilterLoggingTestTrait.groovy
@@ -1,3 +1,15 @@
+/*
+ * Copyright (c) 2016-present Sonatype, Inc. All rights reserved.
+ *
+ * This program is licensed to you under the Apache License Version 2.0,
+ * and you may not use this file except in compliance with the Apache License Version 2.0.
+ * You may obtain a copy of the Apache License Version 2.0 at http://www.apache.org/licenses/LICENSE-2.0.
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the Apache License Version 2.0 is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the Apache License Version 2.0 for the specific language governing permissions and limitations there under.
+ */
 package org.sonatype.nexus.ci.iq
 
 import java.util.logging.Level

--- a/src/test/java/org/sonatype/nexus/ci/iq/ClassFilterLoggingTestTrait.groovy
+++ b/src/test/java/org/sonatype/nexus/ci/iq/ClassFilterLoggingTestTrait.groovy
@@ -13,7 +13,6 @@
 package org.sonatype.nexus.ci.iq
 
 import java.util.logging.Level
-import java.util.logging.LogRecord
 
 import org.jenkinsci.plugins.workflow.cps.CpsFlowExecution
 import org.junit.After
@@ -44,11 +43,7 @@ will need to be added to the 'hudson.remoting.ClassFilter' file. See INT-2407 fo
 
   @After
   def runLoggingTest() {
-    for (LogRecord logRecord : loggerRule.records) {
-      if (logRecord.thrown != null) {
-        assertNoClassFilterErrors(logRecord.thrown)
-      }
-    }
+    loggerRule.records.findAll { it.thrown }.each { record -> assertNoClassFilterErrors(record.thrown) }
   }
 
   /**

--- a/src/test/java/org/sonatype/nexus/ci/iq/ClassFilterLoggingTestTrait.groovy
+++ b/src/test/java/org/sonatype/nexus/ci/iq/ClassFilterLoggingTestTrait.groovy
@@ -24,14 +24,14 @@ import org.slf4j.LoggerFactory
 
 /**
  * Add this trait to any test that should have an extra verification that no JEP-200 marshalling errors have occurred.
- * See INT-2407 for additional information and INT-418 for original work.
+ * See INT-2407 and https://docs.sonatype.com/x/op5NCQ for additional information and INT-418 for the original work.
  */
 trait ClassFilterLoggingTestTrait
 {
   Logger logger = LoggerFactory.getLogger(ClassFilterLoggingTestTrait)
 
   @Rule
-  public LoggerRule loggerRule = new LoggerRule()
+  LoggerRule loggerRule = new LoggerRule()
 
   def helpfulMessage = '''A possible JEP-200 marshalling error has occurred. It is likely that additional classes 
 will need to be added to the 'hudson.remoting.ClassFilter' file. See INT-2407 for additional info'''

--- a/src/test/java/org/sonatype/nexus/ci/iq/ClassFilterLoggingTestTrait.groovy
+++ b/src/test/java/org/sonatype/nexus/ci/iq/ClassFilterLoggingTestTrait.groovy
@@ -1,0 +1,55 @@
+package org.sonatype.nexus.ci.iq
+
+import java.util.logging.Level
+import java.util.logging.LogRecord
+
+import org.jenkinsci.plugins.workflow.cps.CpsFlowExecution
+import org.junit.After
+import org.junit.Before
+import org.junit.Rule
+import org.jvnet.hudson.test.LoggerRule
+import org.slf4j.Logger
+import org.slf4j.LoggerFactory
+
+/**
+ * Add this trait to any test that should have an extra verification that no JEP-200 marshalling errors have occurred.
+ * See INT-2407 for additional information and INT-418 for original work.
+ */
+trait ClassFilterLoggingTestTrait
+{
+  Logger logger = LoggerFactory.getLogger(ClassFilterLoggingTestTrait)
+
+  @Rule
+  public LoggerRule loggerRule = new LoggerRule()
+
+  def helpfulMessage = '''A possible JEP-200 marshalling error has occurred. It is likely that additional classes 
+will need to be added to the 'hudson.remoting.ClassFilter' file. See INT-2407 for additional info'''
+
+  @Before
+  def setupLoggingTest() {
+    loggerRule.capture(10).record(CpsFlowExecution, Level.WARNING)
+  }
+
+  @After
+  def runLoggingTest() {
+    for (LogRecord logRecord : loggerRule.records) {
+      if (logRecord.thrown != null) {
+        assertNoClassFilterErrors(logRecord.thrown)
+      }
+    }
+  }
+
+  /**
+   * Recursively look at the causes for specific keywords. Note: These might change over time which would render this
+   * test moot. Hence we are checking for a few keywords including the specific redirect URL.
+   */
+  def assertNoClassFilterErrors(Throwable throwable) {
+    def msg = throwable.message
+    assert !msg.contains("Failed to serialize"), helpfulMessage
+    assert !msg.contains("Refusing to marshal"), helpfulMessage
+    assert !msg.contains("https://jenkins.io/redirect/class-filter/"), helpfulMessage
+    if (throwable.cause != null) {
+      assertNoClassFilterErrors(throwable.cause)
+    }
+  }
+}

--- a/src/test/java/org/sonatype/nexus/ci/iq/ClassFilterLoggingTestTrait.groovy
+++ b/src/test/java/org/sonatype/nexus/ci/iq/ClassFilterLoggingTestTrait.groovy
@@ -34,7 +34,7 @@ trait ClassFilterLoggingTestTrait
   LoggerRule loggerRule = new LoggerRule()
 
   def helpfulMessage = '''A possible JEP-200 marshalling error has occurred. It is likely that additional classes 
-will need to be added to the 'hudson.remoting.ClassFilter' file. See INT-2407 for additional info'''
+will need to be added to the 'hudson.remoting.ClassFilter' file. See https://docs.sonatype.com/x/op5NCQ'''
 
   @Before
   def setupLoggingTest() {

--- a/src/test/java/org/sonatype/nexus/ci/iq/IqPolicyEvaluatorIntegrationTest.groovy
+++ b/src/test/java/org/sonatype/nexus/ci/iq/IqPolicyEvaluatorIntegrationTest.groovy
@@ -12,8 +12,6 @@
  */
 package org.sonatype.nexus.ci.iq
 
-import java.util.logging.Level
-import java.util.logging.LogRecord
 
 import com.sonatype.insight.scan.model.Scan
 import com.sonatype.nexus.api.exception.IqClientException
@@ -39,13 +37,10 @@ import hudson.model.Result
 import hudson.slaves.EnvironmentVariablesNodeProperty
 import jenkins.model.Jenkins
 import org.jenkinsci.plugins.workflow.cps.CpsFlowDefinition
-import org.jenkinsci.plugins.workflow.cps.CpsFlowExecution
 import org.jenkinsci.plugins.workflow.job.WorkflowJob
 import org.junit.Rule
-import org.junit.rules.RuleChain
 import org.jvnet.hudson.test.ExtractResourceSCM
 import org.jvnet.hudson.test.JenkinsRule
-import org.jvnet.hudson.test.LoggerRule
 import spock.lang.Specification
 import spock.lang.Unroll
 
@@ -106,7 +101,8 @@ class IqPolicyEvaluatorIntegrationTest
       1 * iqClient.verifyOrCreateApplication(*_) >> true
       1 * iqClient.scan(*_) >> new ScanResult(new Scan(), File.createTempFile('dummy-scan', '.xml.gz'))
       1 * iqClient.evaluateApplication(*_) >>
-          new ApplicationPolicyEvaluation(0, 1, 2, 3, 0, [], 'http://server/link/to/report')
+          new ApplicationPolicyEvaluation(0, 1, 2, 3, 0, [createAlert(Action.ID_NOTIFY)],
+              'http://server/link/to/report')
 
     and: 'the build is successful'
       jenkins.assertBuildStatusSuccess(build)

--- a/src/test/java/org/sonatype/nexus/ci/iq/IqPolicyEvaluatorIntegrationTest.groovy
+++ b/src/test/java/org/sonatype/nexus/ci/iq/IqPolicyEvaluatorIntegrationTest.groovy
@@ -12,6 +12,8 @@
  */
 package org.sonatype.nexus.ci.iq
 
+import java.util.logging.Level
+import java.util.logging.LogRecord
 
 import com.sonatype.insight.scan.model.Scan
 import com.sonatype.nexus.api.exception.IqClientException
@@ -37,10 +39,13 @@ import hudson.model.Result
 import hudson.slaves.EnvironmentVariablesNodeProperty
 import jenkins.model.Jenkins
 import org.jenkinsci.plugins.workflow.cps.CpsFlowDefinition
+import org.jenkinsci.plugins.workflow.cps.CpsFlowExecution
 import org.jenkinsci.plugins.workflow.job.WorkflowJob
 import org.junit.Rule
+import org.junit.rules.RuleChain
 import org.jvnet.hudson.test.ExtractResourceSCM
 import org.jvnet.hudson.test.JenkinsRule
+import org.jvnet.hudson.test.LoggerRule
 import spock.lang.Specification
 import spock.lang.Unroll
 
@@ -48,6 +53,7 @@ import static org.sonatype.nexus.ci.iq.TestDataGenerators.createAlert
 
 class IqPolicyEvaluatorIntegrationTest
     extends Specification
+    implements ClassFilterLoggingTestTrait
 {
   @Rule
   public JenkinsRule jenkins = new JenkinsRule()

--- a/src/test/java/org/sonatype/nexus/ci/iq/IqPolicyEvaluatorSlaveIntegrationTest.groovy
+++ b/src/test/java/org/sonatype/nexus/ci/iq/IqPolicyEvaluatorSlaveIntegrationTest.groovy
@@ -49,6 +49,7 @@ import static com.github.tomakehurst.wiremock.core.WireMockConfiguration.wireMoc
  */
 class IqPolicyEvaluatorSlaveIntegrationTest
     extends Specification
+    implements ClassFilterLoggingTestTrait
 {
   @Rule
   public JenkinsRule jenkins = new JenkinsRule()


### PR DESCRIPTION
Jira: https://issues.sonatype.org/browse/INT-2451
CI: https://jenkins.ci.sonatype.dev/job/integrations/job/jenkins/job/sonatype-nexus-platform-plugin-feature/job/INT-2451-jep-200-tests/

The curious case of JEP-200 continues. So this PR is based off `master`, which does not manifest the error because it uses an old version of Jenkins by default. Plus, the fix for the INT-2407 is merged into `master` so it won't throw the error anyways.

My vote is to wait for https://github.com/jenkinsci/nexus-platform-plugin/pull/111 to be merged upstream, then rebase it all at which point it will be possible for us to get an error. Then, to make sure this even works, we'd have to back some of the classes out of the `ClassFilter` file so we can properly test this.

Thoughts?